### PR TITLE
changes ZMQ ReaderSingleton threads to daemon=True

### DIFF
--- a/retico_zmq/zmq.py
+++ b/retico_zmq/zmq.py
@@ -110,9 +110,9 @@ class ReaderSingleton(retico_core.AbstractModule):
             self.queue.append((topic,message))
 
     def prepare_run(self):
-        t = threading.Thread(target=self.run_reader)
+        t = threading.Thread(target=self.run_reader, daemon=True)
         t.start()
-        t = threading.Thread(target=self.run_process)
+        t = threading.Thread(target=self.run_process, daemon=True)
         t.start()
 
 


### PR DESCRIPTION
Fixes the same issue that WriterSingleton had with spawning threads that wouldn't close properly.