### PR TITLE
Update ZMQ to send pickled IUs 

### DIFF
--- a/retico_zmq/zmq.py
+++ b/retico_zmq/zmq.py
@@ -9,17 +9,19 @@ information revceived over the ZeroMQ bridge.
 
 # retico
 import retico_core
-from retico_core.abstract import *
 
 # zeromq & supporting libraries
 import zmq, json
 import threading
-import datetime
 import time
 from collections import deque
+import pickle
 
 zmq_delimiter = '_!_'
 
+# Keeping for Backwards Compatibility, the ReaderModule supports ZMQ objects and
+# and allows reader->module subscriptions using ZMQ topics to ensure the appropriate reader
+# instance receives the message
 class ReaderSingleton(retico_core.AbstractModule):
 
     """A ZeroMQ Reader Module
@@ -54,7 +56,7 @@ class ReaderSingleton(retico_core.AbstractModule):
         self.queue = deque()
         self.target_iu_types = {}
         self.socket = zmq.Context().socket(zmq.SUB)
-        self.socket.connect("tcp://{}:{}".format(ip, port))    
+        self.socket.connect("tcp://{}:{}".format(ip, port))
 
     def process_update(self, input_iu):
         """
@@ -116,6 +118,79 @@ class ReaderSingleton(retico_core.AbstractModule):
         t.start()
 
 
+class ZMQReaderModule(retico_core.AbstractModule):
+
+    """A ZeroMQ Reader Module
+
+    Attributes:
+
+    """
+
+    def name(self):
+        return f"[ZMQ] {str(self.expected_iu_type)}"
+
+    @staticmethod
+    def description():
+        return "A Module providing reading from a ZeroMQ bus"
+
+    @staticmethod
+    def input_ius():
+        return []
+
+    def output_iu(self):
+        return self.expected_iu_type
+
+    def __init__(self, ip, port, topic, expected_iu_type, **kwargs):
+        """Initializes the ZeroMQReader.
+
+        Args: topic(str): the topic/scope where the information will be read.
+
+        """
+        super().__init__(**kwargs)
+        self.queue = deque()
+        self.target_iu_types = {}
+        self.socket = zmq.Context().socket(zmq.SUB)
+        self.socket.connect("tcp://{}:{}".format(ip, port))
+        self.topic = topic
+        self.socket.subscribe(topic)
+        self.expected_iu_type = expected_iu_type
+
+    def process_update(self, input_iu):
+        """
+        As an edge case, process_update is not used for Reader Modules because updates do not come from being subscribed to another module.
+        Rather, they come from populating a queue with messages from the ZMQ writer filtered by the appropriate topic
+        """
+        # the _run function in the Abstract module we inherit expects to be able to call process update. Return None as a no-op
+        return None
+
+    def process_message(self):
+        """
+        Read ZMQ message from reader queue, load input IU from pickle, and pass along
+        """
+        while True:
+            time.sleep(0.02) # prevent tight loop if queue is empty
+            if len(self.queue) > 0:
+                message = self.queue.popleft()
+                input_iu, update_type = pickle.loads(message)
+                um = retico_core.UpdateMessage.from_iu(input_iu, update_type) # pass input IU on using its own update type
+                self.append(um)
+
+    def run_reader(self):
+        """
+        Wait for messages from the writer for the defined topic, add to queue to be processed
+        ZMQ handles topic management
+        """
+        while True:
+            topic,message = self.socket.recv_multipart()
+            self.queue.append(message)
+
+    def prepare_run(self):
+        t = threading.Thread(target=self.run_reader, daemon=True)
+        t.start()
+        t = threading.Thread(target=self.process_message, daemon=True)
+        t.start()
+
+
 class WriterSingleton:
     __instance = None
 
@@ -136,7 +211,7 @@ class WriterSingleton:
             t.daemon = True
             t.start()
 
-    def send(self, data):
+    def add_to_queue(self, data):
         self.queue.append(data)
 
     def run_writer(self):
@@ -144,144 +219,15 @@ class WriterSingleton:
             if len(self.queue) == 0:
                 time.sleep(0.1)
                 continue
+            # Once we are sending only pickled IU objects, we can remove the logic checking for json and just unpack
+            # topic, message, and update_type from the queue
+            # topic, message, update_type = self.queue.popleft()
             data = self.queue.popleft()
-            self.socket.send_string(data)
-
-
-# class ZeroMQIU(retico_core.IncrementalUnit):
-#     @staticmethod
-#     def type():
-#         return "ZeroMQ Incremental Unit"
-
-#     def __init__(
-#         self,
-#         creator=None,
-#         iuid=0,
-#         previous_iu=None,
-#         grounded_in=None,
-#         payload=None,
-#         **kwargs
-#     ):
-#         """Initialize the DialogueActIU with act and concepts.
-
-#         Args:
-#             act (string): A representation of the act.
-#             concepts (dict): A representation of the concepts as a dictionary.
-#         """
-#         super().__init__(
-#             creator=creator,
-#             iuid=iuid,
-#             previous_iu=previous_iu,
-#             grounded_in=grounded_in,
-#             payload=payload,
-#         )
-
-#     def set_payload(self, payload):
-#         self.payload = payload
-
-
-# class ZeroMQReader(retico_core.AbstractModule):
-
-#     """A ZeroMQ Reader Module
-
-#     Attributes:
-
-#     """
-
-#     @staticmethod
-#     def name():
-#         return "ZeroMQ Reader Module"
-
-#     @staticmethod
-#     def description():
-#         return "A Module providing reading from a ZeroMQ bus"
-
-#     @staticmethod
-#     def output_iu():
-#         return IncrementalUnit
-
-#     def __init__(self, topic, target_iu_type, **kwargs):
-#         """Initializes the ZeroMQReader.
-
-#         Args: topic(str): the topic/scope where the information will be read.
-
-#         """
-#         super().__init__(**kwargs)
-#         self.topic = topic
-#         self.reader = None
-#         self.queue = deque()
-#         self.target_iu_type = target_iu_type
-
-#     def process_update(self, input_iu):
-#         """
-#         This assumes that the message is json formatted, then packages it as payload into an IU
-#         """
-
-#         return None
-
-#     def run_process(self):
-
-#         while True:
-#             time.sleep(0.2)
-#             if len(self.queue) > 0:
-#                 print("ZMQ Reader process update", self.topic)
-#                 message = self.queue.popleft()
-#                 j = json.loads(message)
-#                     # print(self.topic, topic.decode())
-                
-#                 output_iu = self.target_iu_type(
-#                             creator=self,
-#                             iuid=f"{hash(self)}:{self.iu_counter}",
-#                             previous_iu=self._previous_iu,
-#                             grounded_in=None,
-#                         )
-#                 self.iu_counter += 1
-#                 self._previous_iu = output_iu
-                
-#                 output_iu.from_zmq(j)
-
-#                 update_message = retico_core.UpdateMessage()
-
-#                 if "update_type" not in j:
-#                     print("Incoming IU has no update_type!")
-#                 if j["update_type"] == "UpdateType.ADD":
-#                     update_message.add_iu(output_iu, retico_core.UpdateType.ADD)
-#                 elif j["update_type"] == "UpdateType.REVOKE":
-#                     update_message.add_iu(output_iu, retico_core.UpdateType.REVOKE)
-#                 elif j["update_type"] == "UpdateType.COMMIT":
-#                     update_message.add_iu(output_iu, retico_core.UpdateType.COMMIT)
-#                 # print('iu created by ', self.topic)
-#                 self.append(update_message)        
-    
-#     def run_reader(self):
-#         # print(self.topic)
-#         while True:
-#             topic,message = self.reader.recv_string().split(zmq_delimiter)
-#             # print(self.topic)
-#             # I hate these two stupid hacks, but sometimes
-#             # the recv_multipart function is missing the topic
-#             # if len(data) != 2: return None
-#             # print(type(data[0].decode()))
-#             # if type(data[0].decode()) != str: return None
-            
-#             # topic,message = data
-#             # print(self.topic, topic, self.topic==topic)
-#             if self.topic != topic: # only deal with IUs designated for this topic
-#                 continue
-
-#             self.queue.append(message)
-
-            
-
-#     def prepare_run(self):
-#         self.reader = ReaderSingleton.getInstance().socket
-#         # self.reader.setsockopt(zmq.SUBSCRIBE, self.topic)
-#         self.reader.subscribe(self.topic)
-#         t = threading.Thread(target=self.run_reader)
-#         t.start()
-#         t = threading.Thread(target=self.run_process)
-#         t.start()        
-
+            if len(data) == 3:
+                topic, message, update_type = data
+                self.socket.send_multipart([topic.encode(), pickle.dumps((message, update_type))])
+            else:
+                self.socket.send_string(data)
 
 class ZeroMQWriter(retico_core.AbstractModule):
 
@@ -309,7 +255,7 @@ class ZeroMQWriter(retico_core.AbstractModule):
     def input_ius():
         return [retico_core.IncrementalUnit]
 
-    def __init__(self, topic, **kwargs):
+    def __init__(self, topic, use_json=True, **kwargs):
         """Initializes the ZeroMQReader.
 
         Args: topic(str): the topic/scope where the information will be read.
@@ -319,112 +265,20 @@ class ZeroMQWriter(retico_core.AbstractModule):
         self.topic = topic
         self.queue = deque()  # no maxlen
         self.writer = WriterSingleton.getInstance()
+        self.use_json = use_json # remove this when fully moved to sending pickled IU objects over ZMQ
 
     def process_update(self, update_message):
         """
-        This assumes that the message is json formatted, then packages it as payload into an IU
+        Adds the IU to the writer queue
         """
-        # print("ZMQ Writer process update", self.topic)        
-        for input_iu,um in update_message:
-            self.writer.send(
-                self.topic + zmq_delimiter + json.dumps(input_iu.to_zmq(um))
-            )
-            # time.sleep(0.1)
-
+        for input_iu,update_type in update_message:
+            # Once we are only sending pickled IU objects, we can drop the if logic
+            if self.use_json:
+                # This assumes that the message is json formatted, then packages it as payload into an IU
+                self.writer.add_to_queue(self.topic + zmq_delimiter + json.dumps(input_iu.to_zmq(update_type)))
+            else:
+                self.writer.add_to_queue([self.topic, input_iu, update_type])
         return None
-        # for um in update_message:
-        #     self.queue.append(um)
-        # for input_iu,um in update_message:
-        #     # print('sending', self.topic)
-        #     # print(input_iu.payload)
-        #     # if isinstance(input_iu, ImageIU) or isinstance(input_iu, DetectedObjectsIU)  or isinstance(input_iu, ObjectFeaturesIU):
-        #     #     payload['message'] = json.dumps(input_iu.get_json())
-        #     self.writer.send_string(
-        #        self.topic + zmq_delimiter + json.dumps(input_iu.to_zmq(um))
-        #     )
-
-        # return None
-
-    # def run_writer(self):
-
-    #     while True:
-    #         if len(self.queue) == 0:
-    #             time.sleep(0.5)
-    #             continue
-    #         input_iu, ut = self.queue.popleft()
-    #         # print('sending', self.topic)
-    #         # print(input_iu.payload)
-    #         # if isinstance(input_iu, ImageIU) or isinstance(input_iu, DetectedObjectsIU)  or isinstance(input_iu, ObjectFeaturesIU):
-    #         #     payload['message'] = json.dumps(input_iu.get_json())
-    #         self.writer.send_string(
-    #            self.topic + zmq_delimiter + json.dumps(input_iu.to_zmq(ut))
-    #         )
 
     def prepare_run(self):
         pass
-        # self.writer = WriterSingleton.getInstance().socket
-        # t = threading.Thread(target=self.run_writer)
-        # t.start()
-
-
-# class ZMQtoImage(retico_core.AbstractModule):
-#     @staticmethod
-#     def name():
-#         return "ZMQtoASR"
-#     @staticmethod
-#     def description():
-#         return "Convert ZeroMQIU to SpeechRecognitionIU"
-#     @staticmethod
-#     def input_ius():
-#         return [ZeroMQIU]
-#     @staticmethod
-#     def output_iu():
-#         return ImageIU
-
-#     def __init__(self, **kwargs):
-#         super().__init__(**kwargs)
-
-#     def process_update(self,update_message):
-
-#         for iu,um in update_message:
-#             # print("getting ZMQ", iu.payload['message'])
-#             output_iu = self.create_iu(iu)
-#             output_iu.create_from_json(json.loads(iu.payload['message']))
-#             # self.current_ius.append(output_iu)
-#             new_um = retico_core.UpdateMessage.from_iu(output_iu, um)
-            
-#         return new_um
-
-#     def setup(self):
-#         pass
-
-
-# class ZMQtoDetectedObjects(retico_core.AbstractModule):
-#     @staticmethod
-#     def name():
-#         return "ZMQtoDetectedObjects"
-#     @staticmethod
-#     def description():
-#         return "Convert ZeroMQIU to DetectedObjectsIU"
-#     @staticmethod
-#     def input_ius():
-#         return [ZeroMQIU]
-#     @staticmethod
-#     def output_iu():
-#         return ObjectFeaturesIU
-
-#     def __init__(self, **kwargs):
-#         super().__init__(**kwargs)
-
-#     def process_update(self,update_message):
-#         for iu,um in update_message:
-#             # print("getting ZMQ", iu.payload['message'])
-#             output_iu = self.create_iu(iu)
-#             output_iu.create_from_json(json.loads(iu.payload['message']))
-#             # self.current_ius.append(output_iu)
-#             new_um = retico_core.UpdateMessage.from_iu(output_iu, um)
-            
-#         return new_um
-
-#     def setup(self):
-#         pass

--- a/retico_zmq/zmq.py
+++ b/retico_zmq/zmq.py
@@ -127,7 +127,7 @@ class ZMQReaderModule(retico_core.AbstractModule):
     """
 
     def name(self):
-        return f"[ZMQ] {str(self.expected_iu_type)}"
+        return f"ZMQ Reader Module"
 
     @staticmethod
     def description():
@@ -135,12 +135,15 @@ class ZMQReaderModule(retico_core.AbstractModule):
 
     @staticmethod
     def input_ius():
+        # Input IUs are not relevant here because we receive IUs from ZMQ message queue not from the output of a module
         return []
-
+    
+    @staticmethod
     def output_iu(self):
-        return self.expected_iu_type
+        # output IU does not have any impact because this module does not create any IUs, just passes existing ones on.
+        pass
 
-    def __init__(self, ip, port, topic, expected_iu_type, **kwargs):
+    def __init__(self, ip, port, topic, **kwargs):
         """Initializes the ZeroMQReader.
 
         Args: topic(str): the topic/scope where the information will be read.
@@ -153,7 +156,6 @@ class ZMQReaderModule(retico_core.AbstractModule):
         self.socket.connect("tcp://{}:{}".format(ip, port))
         self.topic = topic
         self.socket.subscribe(topic)
-        self.expected_iu_type = expected_iu_type
 
     def process_update(self, input_iu):
         """


### PR DESCRIPTION
Update ZMQ in a (hopefully) backwards compatible way to send and receive pickled IU objects over ZMQ and use a ReaderModule instead of ReaderSingleton 

*Changes in retico-core are required for these code changes to work! https://github.com/retico-team/retico-core/compare/support_pickling_ius?expand=1*

Your runner will need to change to use `ZMQReaderModule` instead of the Singleton. My runners have the following:
```python
WriterSingleton(ip=CLIENT_IP, port='12346')  # create ZeroMQ writer
zmq_GRED_emotion_reader = ZMQReaderModule(ip=SERVER_IP, port='12348', topic='GRED_emotion') 
zmq_cozmo_custom_object_reader = ZMQReaderModule(ip=SERVER_IP, port='12348', topic='cozmo_custom_object')
# perform the GRED emotion using EMRO action executor
zmq_GRED_emotion_reader.subscribe(action_executor)
# add the seen object to Cozmo's nav map for path planning
zmq_cozmo_custom_object_reader.subscribe(cozmo_object_permanence)
zmq_cozmo_custom_object_reader.run()
zmq_GRED_emotion_reader.run()
<input>
zmq_GRED_emotion_reader.stop()
zmq_cozmo_custom_object_reader.stop()
```

Also, I haven't tested this with a retico pipeline that uses any revokes. 