### PR TITLE
Reduce size of serialized IUs sent over ZMQ

### DIFF
--- a/retico_zmq/zmq.py
+++ b/retico_zmq/zmq.py
@@ -229,9 +229,11 @@ class WriterSingleton:
             data = self.queue.popleft()
             if len(data) == 3:
                 topic, message, update_type = data
-                # Keep 4 (0 indexed) layers of 'grounded_in', 'previous_iu', and 'creator' delete the rest to reduce the
+                # Keep `max_nested_iu_depth` (0 indexed) layers of 'grounded_in', 'previous_iu', and 'creator' delete the rest to reduce the
                 # size of messages we are sending over ZMQ
-                delete_nested_attributes(obj=message, target_attrs=['grounded_in', 'previous_iu'], target_deletion_depth=self.max_nested_iu_depth)
+                # NOTE: This does break IU chain of information
+                if self.max_nested_iu_depth != -1: # Set max_nested_iu_depth to -1 if you do not want any data deleted before serializing 
+                    delete_nested_attributes(obj=message, target_attrs=['grounded_in', 'previous_iu'], target_deletion_depth=self.max_nested_iu_depth)
                 self.socket.send_multipart([topic.encode(), pickle.dumps((message, update_type))])
             else:
                 self.socket.send_string(data)

--- a/retico_zmq/zmq.py
+++ b/retico_zmq/zmq.py
@@ -201,9 +201,11 @@ class WriterSingleton:
         """Static access method."""
         return WriterSingleton.__instance
 
-    def __init__(self, ip, port):
+    def __init__(self, ip, port, max_nested_iu_depth=3):
         """Virtually private constructor."""
         if WriterSingleton.__instance is None:
+            # To prevent sending too large of an object over zmq, reduce the number of nested IUs.
+            self.max_nested_iu_depth = max_nested_iu_depth
             context = zmq.Context()
             self.queue = deque()
             self.socket = context.socket(zmq.PUB)
@@ -227,6 +229,9 @@ class WriterSingleton:
             data = self.queue.popleft()
             if len(data) == 3:
                 topic, message, update_type = data
+                # Keep 4 (0 indexed) layers of 'grounded_in', 'previous_iu', and 'creator' delete the rest to reduce the
+                # size of messages we are sending over ZMQ
+                delete_nested_attributes(obj=message, target_attrs=['grounded_in', 'previous_iu'], target_deletion_depth=self.max_nested_iu_depth)
                 self.socket.send_multipart([topic.encode(), pickle.dumps((message, update_type))])
             else:
                 self.socket.send_string(data)
@@ -284,3 +289,27 @@ class ZeroMQWriter(retico_core.AbstractModule):
 
     def prepare_run(self):
         pass
+
+
+def delete_nested_attributes(obj, target_attrs, target_deletion_depth, current_depth=0, ):
+    """
+    Recursively delete specified attributes at target depth -- all nested target attributes will be set to 'None' after the target deletion depth
+    Will recurse through target attributes to find if they contain any of the target attributes
+     i.e. (grounded_in -> previous_iu -> grounded_in -> previous_iu)
+    """
+    # We reached the target depth, delete the attribute
+    if current_depth == target_deletion_depth:
+        for target_attr in target_attrs:
+            if isinstance(obj, dict) and target_attr in obj:
+                obj[target_attr] = None
+            elif hasattr(obj, '__dict__') and hasattr(obj, target_attr):
+                setattr(obj, target_attr, None)
+        return
+
+    for target_attr in target_attrs:
+        # check if dict
+        if isinstance(obj, dict) and target_attr in obj:
+            delete_nested_attributes(obj[target_attr], target_attrs, target_deletion_depth, current_depth + 1)
+        # check if a python obj and if it has the attr
+        elif hasattr(obj, '__dict__') and hasattr(obj, target_attr):
+            delete_nested_attributes(getattr(obj, target_attr), target_attrs, target_deletion_depth, current_depth + 1)


### PR DESCRIPTION
add function `delete_nested_attributes(...)` to delete the _n_th layer of grounded_in and previous_iu. With each IU having a `previous_iu` and a  `grounded_in` with each of those having a `previous_iu` and `grounded_in`, it makes sense that our objects were rapidly growing in size

I was seeing serialized object sizes of 200+ MB which were taking 70+ seconds to send. In the screenshot attached you can see that even a fairly nested (`grounded_in.grounded_in.grounded_in.previous_iu.previous_iu`) was ~63 Megabytes.
<img width="2810" height="1428" alt="image" src="https://github.com/user-attachments/assets/17f14308-9710-411b-86b7-bdbcaa544cea" />


After this change I ran for 60 executions, every message was about 1mb or under and sent over ZMQ in about 1 second. I did set the default to keep 4 layers because I needed to access `grounded_in` IUs that far back, but folks can definitely adjust for whatever suits their needs though it will be a tradeoff of more data for slower sends.