### PR TITLE
Adds zmq_creator to metadata for tracking ZMQ creators in MaAI modules.

### DIFF
--- a/retico_zmq/zmq.py
+++ b/retico_zmq/zmq.py
@@ -174,6 +174,7 @@ class ZMQReaderModule(retico_core.AbstractModule):
             if len(self.queue) > 0:
                 message = self.queue.popleft()
                 input_iu, update_type = pickle.loads(message)
+                input_iu.meta_data['zmq_creator'] = self
                 um = retico_core.UpdateMessage.from_iu(input_iu, update_type) # pass input IU on using its own update type
                 self.append(um)
 


### PR DESCRIPTION
**Context:**
MaAI modules infer audio sources (modules sending AudioIUs) by collecting the left buffer providers during setup and using them as keys for a dictionary. Each IU's creator field is then used to query that dictionary for internal routing. 

**Why the patch:**
IUs coming from ZMQReaderModules have their creator field overwritten to an 'AnonymousCreator', but this doesn't correspond to the actual ZMQReaderModule object that is stored when scanning left buffer providers. 

This patch tags each IU that passes through a ZMQReaderModule with a metadata key:value pair, pairing 'zmq_creator' with a reference to the ZMQ module object. MaAI modules then use this object reference to query the internal dictionary of audio sources for handling IUs properly.